### PR TITLE
Added new method to assign you own typeface

### DIFF
--- a/core/src/main/java/com/github/stephenvinouze/materialnumberpickercore/MaterialNumberPicker.kt
+++ b/core/src/main/java/com/github/stephenvinouze/materialnumberpickercore/MaterialNumberPicker.kt
@@ -60,6 +60,8 @@ class MaterialNumberPicker : NumberPicker {
             field = value
             updateTextAttributes()
         }
+    private var fontNameTypeFace: Typeface? = null
+
     private val inputEditText: EditText? by lazy {
         try {
             val f = NumberPicker::class.java.getDeclaredField("mInputText")
@@ -149,10 +151,18 @@ class MaterialNumberPicker : NumberPicker {
     }
 
     /**
+     *  Set the font name using your own typeface (example: if you have the font in the resources folder)
+     */
+    private fun setFontName(typeface: Typeface) {
+        fontNameTypeFace = typeface
+        updateTextAttributes()
+    }
+
+    /**
      * Uses reflection to access text size private attribute for both wheel and edit text inside the number picker.
      */
     private fun updateTextAttributes() {
-        val typeface = if (fontName != null)
+        val typeface = fontNameTypeFace ?: if (fontName != null)
             Typeface.createFromAsset(context.assets, "fonts/$fontName")
         else
             Typeface.create(Typeface.DEFAULT, textStyle)


### PR DESCRIPTION
Current Issue: you cannot use the font if you have the font saved in the "res" folder.

With this method, we could add our own typeface object instead of use only the fontName from the assets folder

Example: 
`materialNumberPicker.setFontName(ResourcesCompat.getFont(this, R.font.app_font))`